### PR TITLE
fix: bottle unit toggle + weight dialog automation

### DIFF
--- a/reference/dom-reference.md
+++ b/reference/dom-reference.md
@@ -28,16 +28,23 @@
 
 ## Bottle Dialog (`showBibDlg()`)
 
+**CRITICAL:** `_uinfo.DUnit` must be set BEFORE opening the dialog.
+The dialog reads it at creation time to build dropdowns and unit labels.
+Setting it after dialog open has NO effect on save.
+
 | Field | Selector | Notes |
 |-------|----------|-------|
 | Start time | `#timeinput` | Format: `10:02PM` |
 | End time | `#endtimeinput` | Format: `10:12PM` |
 | Duration (mins) | `#mduration` | Integer |
 | Quantity | `#bibsize input` | **NOT** `#idQty` |
-| Unit display | `#bibunit` | Span - verify after setting |
-| Unit value | `_uinfo.DUnit` | 0=oz, 1=ml |
-| Milk type | `#bibMilk` | Radio button |
-| Formula type | `#bibFormula` | Radio button |
+| Unit display | `#bibunit` | Span — read-only indicator, no toggle handler |
+| Unit control | `_uinfo.DUnit` | 0=oz, 1=ml — SET BEFORE dialog open |
+| Milk type | `input[name="type"][value="Milk"]` | Radio button |
+| Formula type | `input[name="type"][value="Formula"]` | Radio button |
+| Water type | `input[name="type"][value="Water"]` | Radio button |
+| Juice type | `input[name="type"][value="Juice"]` | Radio button |
+| Summary | `#txt` | Auto-generated, disabled by default |
 
 ---
 
@@ -64,6 +71,25 @@
 **Sizes:** `Small`, `Medium`, `Large` (select dropdown)
 
 **Checkboxes:** Diaper Cream, Leak, Open-Air Accident
+
+---
+
+## Weight Dialog (`showWeightDlg()`)
+
+**PREREQUISITE:** Must select a child tab first. Crashes on "All Children" tab
+(`Cannot read properties of undefined (reading 'Name')`).
+
+| Field | Selector | Notes |
+|-------|----------|-------|
+| Unit: lbs | `input[name="unit"][value="1"]` | Radio, checked when DUnit=0 |
+| Unit: lbs/oz | `input[name="unit"][value="2"]` | Radio |
+| Unit: kg | `input[name="unit"][value="3"]` | Radio, checked when DUnit=1 |
+| Weight whole | 1st `<select>` in `#post_dlg_c` | Options: 0-200 |
+| Weight decimal | 2nd `<select>` in `#post_dlg_c` | Options: 0-9 (tenths) |
+| Weight oz | 2nd `<select>` (lbs_oz mode) | Options: 0-15 |
+
+Clicking unit radio triggers `initWeightWheels()` which rebuilds the dropdowns.
+All weights stored internally as oz via `getWeightInOz()`.
 
 ---
 

--- a/snippets/bottle.js
+++ b/snippets/bottle.js
@@ -1,85 +1,125 @@
 // Bottle Feeding Snippet
-// Prerequisites: Dialog opened with showBibDlg(), waited 1.5s
+// IMPORTANT: Set _uinfo.DUnit BEFORE opening the dialog.
+//   _uinfo.DUnit = 1 → ml (dropdown shows ml sizes: 12,25,37,...,250)
+//   _uinfo.DUnit = 0 → oz (dropdown shows oz sizes: 0.5,1,...,10)
+// The dialog reads _uinfo.DUnit at creation time to build the dropdown
+// and unit label. Changing it after the dialog is open has NO effect.
+//
+// Workflow:
+//   1. evaluate: _uinfo.DUnit = 1  (if ml desired)
+//   2. act: click "Bottle" link to open dialog
+//   3. wait 1.5-2s
+//   4. evaluate: this snippet (fill form + save)
 
 (async () => {
   try {
     // === PARAMETERS (modify these) ===
     const CHILD_ID = '4744184165629952';  // Quinn
     const QUANTITY = 60;
-    const UNIT = 'ml';  // 'ml' or 'oz'
-    const TYPE = 'Milk';  // 'Milk' or 'Formula'
-    const DURATION_MINS = 10;
+    const TYPE = 'Milk';  // 'Milk', 'Formula', 'Water', or 'Juice'
     const START_TIME = '';  // Empty = current time, or '10:02PM'
     const NOTES = '';  // Optional notes
     // === END PARAMETERS ===
+    // NOTE: Unit (ml/oz) is controlled by _uinfo.DUnit set BEFORE dialog open.
 
-    await new Promise(r => setTimeout(r, 1500));
-    
-    // Validate dialog
-    const required = ['#bibsize input', '#bibunit', '#bibMilk'];
-    const missing = required.filter(s => !document.querySelector(s));
-    if (missing.length > 0) return 'ERR: Dialog not ready, missing: ' + missing.join(', ');
+    await new Promise(r => setTimeout(r, 500));
 
-    // 1. Select child
+    // Validate dialog is open
+    const qtyInput = document.querySelector('#bibsize input');
+    if (!qtyInput) return 'ERR: Dialog not ready — #bibsize input not found';
+
+    // 1. Select child (activates React form state)
     const childEl = document.getElementById('dlgKid-' + CHILD_ID);
     if (!childEl) return 'ERR: Child not found: ' + CHILD_ID;
     childEl.click();
+    await new Promise(r => setTimeout(r, 200));
 
     // 2. Set start time if specified
     if (START_TIME) {
       const startInput = document.getElementById('timeinput');
       if (startInput) {
-        startInput.value = START_TIME;
-        startInput.dispatchEvent(new Event('change', {bubbles: true}));
-        startInput.dispatchEvent(new Event('input', {bubbles: true}));
+        const proto = Object.getPrototypeOf(startInput);
+        const desc = Object.getOwnPropertyDescriptor(proto, 'value');
+        if (desc) desc.set.call(startInput, START_TIME);
+        else startInput.value = START_TIME;
+        startInput.dispatchEvent(new Event('change', { bubbles: true }));
+        startInput.dispatchEvent(new Event('input', { bubbles: true }));
       }
     }
 
-    // 3. Set duration
-    const mDur = document.getElementById('mduration');
-    if (mDur) mDur.value = DURATION_MINS.toString();
-
-    // 4. CRITICAL: Set unit BEFORE quantity
-    if (UNIT === 'ml') {
-      if (typeof _uinfo !== 'undefined') _uinfo.DUnit = 1;
-      const unitSpan = document.getElementById('bibunit');
-      if (unitSpan) unitSpan.innerText = 'ml';
-    } else {
-      if (typeof _uinfo !== 'undefined') _uinfo.DUnit = 0;
-      const unitSpan = document.getElementById('bibunit');
-      if (unitSpan) unitSpan.innerText = 'oz';
-    }
-    
-    // Verify unit was set correctly
-    const unitCheck = document.getElementById('bibunit')?.innerText;
-    if (unitCheck !== UNIT) return 'ERR: Unit mismatch - expected ' + UNIT + ', got ' + unitCheck;
-
-    // 5. Set quantity
-    const qtyInput = document.querySelector('#bibsize input');
-    if (!qtyInput) return 'ERR: Quantity input not found';
-    qtyInput.value = QUANTITY.toString();
-    qtyInput.dispatchEvent(new Event('change', {bubbles: true}));
-    qtyInput.dispatchEvent(new Event('input', {bubbles: true}));
-
-    // 6. Select type
-    const typeRadio = document.getElementById(TYPE === 'Milk' ? 'bibMilk' : 'bibFormula');
+    // 3. Select type (Milk/Formula/Water/Juice)
+    const typeRadio = document.querySelector('#post_dlg_c input[name="type"][value="' + TYPE + '"]');
     if (typeRadio) typeRadio.click();
+
+    // 4. Set quantity with React-aware native setter
+    const proto = Object.getPrototypeOf(qtyInput);
+    const desc = Object.getOwnPropertyDescriptor(proto, 'value');
+
+    qtyInput.focus();
+    if (desc) desc.set.call(qtyInput, '');
+    else qtyInput.value = '';
+    qtyInput.dispatchEvent(new Event('input', { bubbles: true }));
+    await new Promise(r => setTimeout(r, 50));
+
+    if (desc) desc.set.call(qtyInput, String(QUANTITY));
+    else qtyInput.value = String(QUANTITY);
+    qtyInput.dispatchEvent(new Event('input', { bubbles: true }));
+    qtyInput.dispatchEvent(new Event('change', { bubbles: true }));
+    await new Promise(r => setTimeout(r, 50));
+
+    qtyInput.blur();
+    qtyInput.dispatchEvent(new Event('blur', { bubbles: true }));
+    // Dismiss autocomplete dropdown
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+    await new Promise(r => setTimeout(r, 100));
+
+    // 5. Verify quantity stuck
+    if (qtyInput.value !== String(QUANTITY)) {
+      // Fallback: type char by char
+      qtyInput.focus();
+      if (desc) desc.set.call(qtyInput, '');
+      for (const ch of String(QUANTITY)) {
+        const prev = qtyInput.value || '';
+        if (desc) desc.set.call(qtyInput, prev + ch);
+        else qtyInput.value = prev + ch;
+        qtyInput.dispatchEvent(new Event('input', { bubbles: true }));
+        await new Promise(r => setTimeout(r, 20));
+      }
+      qtyInput.dispatchEvent(new Event('change', { bubbles: true }));
+      qtyInput.blur();
+      await new Promise(r => setTimeout(r, 100));
+    }
+
+    if (qtyInput.value !== String(QUANTITY)) {
+      return 'ERR: Quantity verification failed. Expected ' + QUANTITY + ' but got ' + qtyInput.value;
+    }
+
+    // 6. Verify summary text before saving
+    const summary = document.getElementById('txt')?.value || '';
+    const unit = _uinfo.DUnit === 1 ? 'ml' : 'oz';
+
+    if (!summary.includes(String(QUANTITY))) {
+      return 'ERR: Summary missing quantity. Expected ' + QUANTITY + ' in "' + summary + '"';
+    }
+    if (!summary.toLowerCase().includes(unit)) {
+      return 'ERR: Summary has wrong unit. Expected ' + unit + ' in "' + summary + '"';
+    }
 
     // 7. Optional notes
     if (NOTES) {
       const notesInput = document.querySelector('textarea, input[name*="note"], #notes');
       if (notesInput) {
         notesInput.value = NOTES;
-        notesInput.dispatchEvent(new Event('change', {bubbles: true}));
-        notesInput.dispatchEvent(new Event('input', {bubbles: true}));
+        notesInput.dispatchEvent(new Event('change', { bubbles: true }));
+        notesInput.dispatchEvent(new Event('input', { bubbles: true }));
       }
     }
 
     // 8. Save
     for (const btn of document.querySelectorAll('button')) {
-      if (btn.innerText?.includes('Save') && !btn.disabled) {
+      if (btn.innerText?.trim() === 'Save' && !btn.disabled) {
         btn.click();
-        return 'OK: Saved ' + QUANTITY + UNIT + ' ' + TYPE;
+        return 'OK: Saved ' + QUANTITY + unit + ' ' + TYPE;
       }
     }
     return 'ERR: Save button not found or disabled';

--- a/snippets/weight.js
+++ b/snippets/weight.js
@@ -1,0 +1,119 @@
+// Weight Entry Snippet
+// Prerequisites:
+//   1. Select child tab first (e.g., click "Quinn Erika Kessler" tab)
+//   2. Click "Weight" link to open dialog
+//   3. Wait 2s
+//   4. Execute this snippet via evaluate
+//
+// The weight dialog uses radio buttons for unit (lbs/lbs_oz/kg)
+// and combobox dropdowns for the value.
+
+(async () => {
+  try {
+    // === PARAMETERS (modify these) ===
+    const CHILD_ID = '4744184165629952';  // Quinn
+    const WEIGHT_UNIT = 'kg';  // 'lbs', 'lbs_oz', or 'kg'
+    const WEIGHT_WHOLE = 4;    // Whole number part (lbs or kg)
+    const WEIGHT_DECIMAL = 5;  // Decimal part (0-9): for lbs = tenths, for kg = tenths
+    const WEIGHT_OZ = 0;       // Only used for lbs_oz unit (0-15 oz)
+    const START_TIME = '';      // Empty = current time, or '10:02PM'
+    const NOTES = '';           // Optional notes
+    // === END PARAMETERS ===
+
+    await new Promise(r => setTimeout(r, 500));
+
+    // Validate dialog elements exist
+    const unitRadios = document.querySelectorAll('#post_dlg_c input[name="unit"]');
+    if (unitRadios.length === 0) return 'ERR: Weight dialog not ready — unit radios not found';
+
+    // 1. Select child
+    const childEl = document.getElementById('dlgKid-' + CHILD_ID);
+    if (childEl) {
+      childEl.click();
+      await new Promise(r => setTimeout(r, 200));
+    }
+
+    // 2. Set start time if specified
+    if (START_TIME) {
+      const startInput = document.getElementById('timeinput');
+      if (startInput) {
+        startInput.value = START_TIME;
+        startInput.dispatchEvent(new Event('change', { bubbles: true }));
+        startInput.dispatchEvent(new Event('input', { bubbles: true }));
+      }
+    }
+
+    // 3. Select unit radio
+    const unitMap = { 'lbs': '1', 'lbs_oz': '2', 'kg': '3' };
+    const unitValue = unitMap[WEIGHT_UNIT];
+    if (!unitValue) return 'ERR: Invalid unit: ' + WEIGHT_UNIT + '. Use lbs, lbs_oz, or kg';
+
+    const unitRadio = document.querySelector('#post_dlg_c input[name="unit"][value="' + unitValue + '"]');
+    if (unitRadio) {
+      unitRadio.click();
+      await new Promise(r => setTimeout(r, 300));
+    } else {
+      return 'ERR: Unit radio not found for value ' + unitValue;
+    }
+
+    // 4. Set weight value via the dropdown selects
+    const selects = document.querySelectorAll('#post_dlg_c select');
+
+    if (selects.length >= 1) {
+      selects[0].value = String(WEIGHT_WHOLE);
+      selects[0].dispatchEvent(new Event('change', { bubbles: true }));
+      await new Promise(r => setTimeout(r, 100));
+    }
+
+    if (selects.length >= 2) {
+      if (WEIGHT_UNIT === 'lbs_oz') {
+        selects[1].value = String(WEIGHT_OZ);
+      } else {
+        selects[1].value = String(WEIGHT_DECIMAL);
+      }
+      selects[1].dispatchEvent(new Event('change', { bubbles: true }));
+      await new Promise(r => setTimeout(r, 100));
+    }
+
+    if (WEIGHT_UNIT === 'lbs_oz' && selects.length >= 3) {
+      selects[2].value = String(WEIGHT_DECIMAL);
+      selects[2].dispatchEvent(new Event('change', { bubbles: true }));
+      await new Promise(r => setTimeout(r, 100));
+    }
+
+    // 5. Trigger text update
+    if (typeof _dlg !== 'undefined' && _dlg.setDlgText) {
+      _dlg.setDlgText();
+      await new Promise(r => setTimeout(r, 100));
+    }
+
+    // 6. Verify summary
+    const summary = document.getElementById('txt')?.value || '';
+    if (!summary.includes('weight')) {
+      return 'ERR: Summary does not look like a weight entry: "' + summary + '"';
+    }
+
+    // 7. Optional notes
+    if (NOTES) {
+      const notesInput = document.querySelector('textarea, input[name*="note"], #notes');
+      if (notesInput) {
+        notesInput.value = NOTES;
+        notesInput.dispatchEvent(new Event('change', { bubbles: true }));
+      }
+    }
+
+    // 8. Save
+    for (const btn of document.querySelectorAll('button')) {
+      if (btn.innerText?.trim() === 'Save' && !btn.disabled) {
+        btn.click();
+        const unitLabel = WEIGHT_UNIT === 'lbs_oz'
+          ? WEIGHT_WHOLE + ' lbs ' + WEIGHT_OZ + ' oz'
+          : WEIGHT_WHOLE + '.' + WEIGHT_DECIMAL + ' ' + WEIGHT_UNIT;
+        return 'OK: Saved weight ' + unitLabel;
+      }
+    }
+    return 'ERR: Save button not found or disabled';
+  } catch (e) {
+    return 'ERR: ' + e.message;
+  }
+})()

--- a/snippets/weight.js
+++ b/snippets/weight.js
@@ -26,12 +26,11 @@
     const unitRadios = document.querySelectorAll('#post_dlg_c input[name="unit"]');
     if (unitRadios.length === 0) return 'ERR: Weight dialog not ready — unit radios not found';
 
-    // 1. Select child
+    // 1. Select child (fail fast if not found)
     const childEl = document.getElementById('dlgKid-' + CHILD_ID);
-    if (childEl) {
-      childEl.click();
-      await new Promise(r => setTimeout(r, 200));
-    }
+    if (!childEl) return 'ERR: Child not found: ' + CHILD_ID;
+    childEl.click();
+    await new Promise(r => setTimeout(r, 200));
 
     // 2. Set start time if specified
     if (START_TIME) {
@@ -89,7 +88,7 @@
 
     // 6. Verify summary
     const summary = document.getElementById('txt')?.value || '';
-    if (!summary.includes('weight')) {
+    if (!summary.toLowerCase().includes('weight')) {
       return 'ERR: Summary does not look like a weight entry: "' + summary + '"';
     }
 


### PR DESCRIPTION
## Summary

Fixes two open issues with Baby Connect browser automation:

### Issue #3: Bottle unit toggle (oz ↔ ml) not working
**Root cause:** `showBibDlg()` reads `_uinfo.DUnit` at dialog creation time to build dropdown options (`_mlSize` vs `_ozSize`), unit labels, and save parameters. Changing it after the dialog is open has zero effect.

**Fix:** Set `_uinfo.DUnit = 1` (ml) or `0` (oz) BEFORE clicking the Bottle link. Verified live — dialog correctly shows ml sizes (12-250) and saves as ml.

### Issue #2: Weight dialog not appearing
**Root cause:** `showWeightDlg()` requires `_dlg.kid` to be set, which only happens when a specific child tab is selected. On "All Children" tab, it crashes with `Cannot read properties of undefined (reading 'Name')`.

**Fix:** Select child tab first, then click Weight. Dialog works perfectly with lbs/lbs_oz/kg radio buttons and weight spinners.

### Changes
- `snippets/bottle.js` — Rewritten with correct unit workflow (set DUnit before dialog)
- `snippets/weight.js` — **New** weight entry automation snippet
- `reference/troubleshooting.md` — Updated both issue fixes with root cause analysis
- `reference/dom-reference.md` — Added weight dialog DOM structure + bottle dialog unit notes
- `SKILL.md` — Added weight support, updated unit handling docs

Closes #2
Closes #3